### PR TITLE
fix config file formatting

### DIFF
--- a/so-wazuh/config/ossec.conf
+++ b/so-wazuh/config/ossec.conf
@@ -178,6 +178,11 @@
     <frequency>360</frequency>
   </localfile>
 
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/ossec/logs/active-responses.log</location>
+  </localfile>
+
   <ruleset>
     <!-- Default ruleset -->
     <decoder_dir>ruleset/decoders</decoder_dir>
@@ -189,13 +194,5 @@
     <decoder_dir>etc/decoders</decoder_dir>
     <rule_dir>etc/rules</rule_dir>
   </ruleset>
-
-</ossec_config>
-
-<ossec_config>
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/ossec/logs/active-responses.log</location>
-  </localfile>
 
 </ossec_config>


### PR DESCRIPTION
Fix format of config file so that when so-allow runs, it does not malform the file.